### PR TITLE
I've refactored Calculating_Sigma_Profiles.py to use local ChEMBL_ami…

### DIFF
--- a/Features/Chembl-12C/Mcginn-Sigma-Profile/Calculating_Sigma_Profiles.py
+++ b/Features/Chembl-12C/Mcginn-Sigma-Profile/Calculating_Sigma_Profiles.py
@@ -124,15 +124,13 @@ def predict_sigma_profile(model: GCNModel, graph: Graph) -> np.ndarray:
 
 def main():
     # Input file and copy
-    original_path = r"C:\Users\kamal\Dropbox\0000-ML_Databases\ChEMBL Data (Do NOT Edit)\ChEMBL_amines_12C.csv"
-    copy_path = os.path.join(os.getcwd(), "ChEMBL_amines_12C_copy.csv")
-    shutil.copyfile(original_path, copy_path)
+    original_path = "../ChEMBL_amines_12C.csv"
 
     # Load model
     model = load_gcn_model()
 
     # Read data copy
-    df = pd.read_csv(copy_path)
+    df = pd.read_csv(original_path)
     df["Sigma Profile"] = None
     charge_values = np.linspace(-0.025, 0.025, 51)
 


### PR DESCRIPTION
…nes_12C.csv.

Here's what I did:
- I modified Calculating_Sigma_Profiles.py to read directly from Features/Chembl-12C/ChEMBL_amines_12C.csv.
- I removed the logic that copied this file to ChEMBL_amines_12C_copy.csv within the Mcginn-Sigma-Profile directory.
- This change streamlines the data input process for sigma profile calculation by removing the need for ChEMBL_amines_12C_copy.csv.