### PR TITLE
I've made some changes to simplify how the script `gcn_ffnn_fusion_da…

### DIFF
--- a/gcn_ffnn_fusion_data0/Fusion_Model_Chembl.py
+++ b/gcn_ffnn_fusion_data0/Fusion_Model_Chembl.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -14,6 +15,7 @@ from torch_geometric.nn import GCNConv, global_mean_pool, BatchNorm
 
 from rdkit import Chem
 from rdkit.Chem import rdchem
+
 
 # -------------------------------
 # Data Loading and Preprocessing
@@ -384,4 +386,18 @@ def main():
     # plt.show() # REMOVE OR COMMENT OUT THIS LINE
 
 if __name__ == "__main__":
-    main()
+    script_dir_for_output = os.path.dirname(os.path.abspath(__file__))
+    output_file_path = os.path.join(script_dir_for_output, "output.txt")
+    original_stdout = sys.stdout
+    output_file_handle = None # Keep this for the finally block
+
+    try:
+        # Redirect stdout to file
+        output_file_handle = open(output_file_path, 'w')
+        sys.stdout = output_file_handle
+        main()
+    finally:
+        if sys.stdout.name == output_file_path: # Check if stdout is our file
+             if output_file_handle: # Ensure it's not None
+                output_file_handle.close()
+        sys.stdout = original_stdout # Restore original stdout


### PR DESCRIPTION
…ta0/Fusion_Model_Chembl.py` handles its output. Now, all the information it prints will go directly into a file named `output.txt`, which you'll find in the same directory as the script.

Specifically, I've:
- Removed a part of the code that was managing how output was displayed.
- Made the process of sending output to the file more straightforward within the main part of the script.